### PR TITLE
ci: add GitHub Actions workflow to deploy backend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,34 @@
+name: Deploy Backend to Cloudflare Workers
+
+on:
+  push:
+    branches: ["New-Backend"]
+    paths:
+      - "backend/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
+      - name: Publish to Cloudflare Workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: wrangler deploy


### PR DESCRIPTION
Add a new GitHub Actions workflow to automate deployment of the
backend to Cloudflare Workers. The workflow triggers on pushes to
master or main branches affecting backend files, as well as manual
dispatch. It sets up Node.js, installs dependencies, installs
Wrangler, and deploys the backend using Wrangler with the provided
Cloudflare API token.

This automation ensures consistent and streamlined backend
deployments.