### PR TITLE
Add GitHub Pages origin to CORS

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,7 +19,11 @@ const app = new Hono<{ Bindings: Env }>();
 app.use(
   "*",
   cors({
-    origin: ["http://localhost:5173"],
+    // Allow local dev and GitHub Pages
+    origin: [
+      "http://localhost:5173",
+      "https://tobbe3108.github.io/GoPayShortcuts",
+    ],
     allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
     exposeHeaders: ["Content-Length"],


### PR DESCRIPTION
- Modified CORS configuration to allow requests from local development and the GitHub Pages production origin.
- Added "https://tobbe3108.github.io/GoPayShortcuts" to the allowed origin array.
- Added comment explaining the purpose of the origin entry.
- No other functional changes.