### PR TITLE
Simplify CORS origin list and fix GitHub Pages URL

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,10 +20,7 @@ app.use(
   "*",
   cors({
     // Allow local dev and GitHub Pages
-    origin: [
-      "http://localhost:5173",
-      "https://tobbe3108.github.io/GoPayShortcuts",
-    ],
+    origin: ["http://localhost:5173", "https://tobbe3108.github.io"],
     allowMethods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allowHeaders: ["Content-Type", "Authorization"],
     exposeHeaders: ["Content-Length"],


### PR DESCRIPTION
Updated backend/src/index.ts:
- Consolidated CORS origin array into a single-line list: ["http://localhost:5173", "https://tobbe3108.github.io"]
- Removed redundant multi-line array formatting and corrected the GitHub Pages origin to the main domain without repository path.
This change is a small config cleanup affecting only CORS origin settings; no functional logic changes beyond allowed origins formatting.