### PR TITLE
Standardize Cache-Control headers and add cacheDuration util

### DIFF
--- a/backend/src/endpoints/Shared/cacheDuration.ts
+++ b/backend/src/endpoints/Shared/cacheDuration.ts
@@ -1,7 +1,35 @@
-export function days(days: number): number {
-  return 86400 * days;
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+export const cacheDuration = {
+  seconds(value: number): number {
+    return value * SECOND;
+  },
+  minutes(value: number): number {
+    return value * MINUTE;
+  },
+  hours(value: number): number {
+    return value * HOUR;
+  },
+  days(value: number): number {
+    return value * DAY;
+  },
+} as const;
+
+export function seconds(value: number): number {
+  return cacheDuration.seconds(value);
 }
 
-export function seconds(seconds: number): number {
-  return seconds;
+export function minutes(value: number): number {
+  return cacheDuration.minutes(value);
+}
+
+export function hours(value: number): number {
+  return cacheDuration.hours(value);
+}
+
+export function days(value: number): number {
+  return cacheDuration.days(value);
 }

--- a/backend/src/endpoints/auth/login.ts
+++ b/backend/src/endpoints/auth/login.ts
@@ -48,6 +48,8 @@ export class Login extends OpenAPIRoute {
     const data = await this.getValidatedData<typeof this.schema>();
     const client = createGoPayClient(c);
 
+    c.res.headers.set("Cache-Control", "no-store");
+
     const response = await client.login(data.body.otp);
     if (response instanceof Response) return response; // Error responses
 

--- a/backend/src/endpoints/auth/requestOTP.ts
+++ b/backend/src/endpoints/auth/requestOTP.ts
@@ -53,6 +53,9 @@ export class RequestOTP extends OpenAPIRoute {
     var response = await client.requestOTP(data.body.email);
     if (response instanceof Response) return response; // Error responses
 
-    return new Response(null, { status: 204 });
+    return new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
+    });
   }
 }

--- a/backend/src/endpoints/locations/getLocations.ts
+++ b/backend/src/endpoints/locations/getLocations.ts
@@ -35,7 +35,10 @@ export class GetLocations extends OpenAPIRoute {
       } as GetLocationsResponse;
     });
 
-    c.res.headers.set("Cache-Control", `max-age=${days(30)}`);
+    c.res.headers.set(
+      "Cache-Control",
+      `public, max-age=${days(30)}, stale-while-revalidate=${days(60)}`
+    );
     return locations;
   }
 }

--- a/backend/src/endpoints/menu/getMenu.ts
+++ b/backend/src/endpoints/menu/getMenu.ts
@@ -47,7 +47,10 @@ export class GetMenu extends OpenAPIRoute {
       });
     }
 
-    c.res.headers.set("Cache-Control", `max-age=${days(1)}`);
+    c.res.headers.set(
+      "Cache-Control",
+      `public, max-age=${days(1)}, stale-while-revalidate=${days(1)}`
+    );
     return result;
   }
 }

--- a/backend/src/endpoints/orders/listOrders.ts
+++ b/backend/src/endpoints/orders/listOrders.ts
@@ -130,7 +130,10 @@ export class ListOrders extends OpenAPIRoute {
       })
     ).then((orders) => orders.sort((a, b) => a.date.localeCompare(b.date)));
 
-    c.res.headers.set("Cache-Control", `max-age=${seconds(30)}`);
+    c.res.headers.set(
+      "Cache-Control",
+      `private, max-age=${seconds(10)}, stale-while-revalidate=${seconds(20)}`
+    );
     return { orders: simplifiedOrders };
   }
 }

--- a/backend/src/endpoints/orders/updateDay.ts
+++ b/backend/src/endpoints/orders/updateDay.ts
@@ -75,6 +75,8 @@ export class PatchOrdersState extends OpenAPIRoute {
   async handle(c: AppContext) {
     const client = createGoPayClient(c);
 
+    c.res.headers.set("Cache-Control", "no-store");
+
     const data = await this.getValidatedData<typeof this.schema>();
     const { kitchenId, date, desiredOrders } = data.body;
 

--- a/backend/src/endpoints/products/getProducts.ts
+++ b/backend/src/endpoints/products/getProducts.ts
@@ -67,7 +67,10 @@ export class GetProducts extends OpenAPIRoute {
     if (response instanceof Response) return response;
 
     const productsResponse = extractProducts(response);
-    c.res.headers.set("Cache-Control", `max-age=${days(30)}`);
+    c.res.headers.set(
+      "Cache-Control",
+      `private, max-age=${days(30)}, stale-while-revalidate=${days(60)}`
+    );
     return productsResponse;
   }
 }

--- a/backend/src/goPay/client.ts
+++ b/backend/src/goPay/client.ts
@@ -213,6 +213,7 @@ export class GoPayClient {
       `/suppliers/kitchens/${kitchenId}/payment/paymentDetails/catering`,
       {
         method: "POST",
+        cache: "no-store",
       },
       request
     );
@@ -239,6 +240,7 @@ export class GoPayClient {
       `/orders/catering`,
       {
         method: "POST",
+        cache: "no-store",
       },
       request
     );
@@ -260,6 +262,7 @@ export class GoPayClient {
       `/orders/${orderId}`,
       {
         method: "DELETE",
+        cache: "no-store",
       }
     );
 


### PR DESCRIPTION
- Replace simple days/seconds helpers with a cacheDuration utility providing seconds/minutes/hours/days and small helper functions (seconds, minutes, hours, days) in backend/src/endpoints/Shared/cacheDuration.ts.
- Set Cache-Control: no-store on sensitive endpoints: auth/login, auth/requestOTP (response header), orders/updateDay, and fetch requests in goPay client by adding cache: "no-store" to fetch options in backend/src/goPay/client.ts.
- Add explicit Cache-Control headers to various read endpoints with appropriate directives and TTLs:
  - locations/getLocations: public, max-age=30 days, stale-while-revalidate=60 days
  - menu/getMenu: public, max-age=1 day, stale-while-revalidate=1 day
  - orders/listOrders: private, max-age=10 seconds, stale-while-revalidate=20 seconds
  - products/getProducts: private, max-age=30 days, stale-while-revalidate=60 days
These changes standardize caching behavior across backend endpoints and ensure sensitive operations are not cached by intermediaries or browsers where applicable.