### PR TITLE
feat(orders): show hint when no default order and avoid unnecessary button

### DIFF
--- a/frontend/src/lib/features/orders/templates/DayViewTemplate.svelte
+++ b/frontend/src/lib/features/orders/templates/DayViewTemplate.svelte
@@ -32,6 +32,13 @@
 
 	let loading = $state(true);
 	let orders: Record<string, TemplateOrder[]> = $state({});
+	let hasDefaultOrder = $state(false);
+
+	$effect(() => {
+		defaultStore.getDefault().then((def) => {
+			hasDefaultOrder = def !== null;
+		});
+	});
 	// In-memory prefetch cache keyed by week range (non-reactive to avoid re-run loops)
 	let prefetchCache: Record<string, Record<string, TemplateOrder[]>> = {};
 	const keyForRange = (start: Date, end: Date) =>
@@ -95,28 +102,34 @@
 
 				{#if (isToday(selectedDate) || isFuture(selectedDate)) && [...ordersByDay(orders, selectedDate)].length === 0}
 					<Card>
-						<div class="flex justify-center">
-							<Button
-								variant="transparent"
-								size="sm"
-								ariaLabel="Use default order"
-								onclick={async () => {
-									const def = await defaultStore.getDefault();
-									if (!def) {
-										notifications.info('No saved default order');
-										return;
-									}
-									const cloned = {
-										...def,
-										date: format(selectedDate, 'yyyy-MM-dd'),
-										tempOrder: true
-									};
-									updateOrderForKitchen(orders, cloned);
-								}}
-							>
-								<div class="text-xs text-gray-400 text-center">Use default order</div>
-							</Button>
-						</div>
+						{#if hasDefaultOrder}
+							<div class="flex justify-center">
+								<Button
+									variant="transparent"
+									size="sm"
+									ariaLabel="Use default order"
+									onclick={async () => {
+										const def = await defaultStore.getDefault();
+										if (!def) {
+											notifications.info('No saved default order');
+											return;
+										}
+										const cloned = {
+											...def,
+											date: format(selectedDate, 'yyyy-MM-dd'),
+											tempOrder: true
+										};
+										updateOrderForKitchen(orders, cloned);
+									}}
+								>
+									<div class="text-xs text-gray-400 text-center">Use default order</div>
+								</Button>
+							</div>
+						{:else}
+							<div class="text-xs text-gray-400 text-center">
+								Save an order as default to quickly reuse it
+							</div>
+						{/if}
 					</Card>
 				{/if}
 

--- a/frontend/src/lib/features/orders/templates/WeekGridTemplate.svelte
+++ b/frontend/src/lib/features/orders/templates/WeekGridTemplate.svelte
@@ -33,6 +33,14 @@
 
 	let loading = $state(true);
 	let orders: Record<string, TemplateOrder[]> = $state({});
+	let hasDefaultOrder = $state(false);
+
+	$effect(() => {
+		defaultStore.getDefault().then((def) => {
+			hasDefaultOrder = def !== null;
+		});
+	});
+
 	// In-memory prefetch cache keyed by week range (non-reactive to avoid re-run loops)
 	let prefetchCache: Record<string, Record<string, TemplateOrder[]>> = {};
 	const keyForRange = (start: Date, end: Date) =>
@@ -97,24 +105,30 @@
 
 						{#if (isToday(date) || isFuture(date)) && ordersByDay(orders, date).length === 0}
 							<Card>
-								<div class="flex justify-center">
-									<Button
-										variant="transparent"
-										size="sm"
-										ariaLabel="Use default order"
-										onclick={async () => {
-											const def = await defaultStore.getDefault();
-											if (!def) {
-												notifications.info('No saved default order');
-												return;
-											}
-											const cloned = { ...def, date: format(date, 'yyyy-MM-dd'), tempOrder: true };
-											updateOrderForKitchen(orders, cloned);
-										}}
-									>
-										<div class="text-xs text-gray-400 text-center">Use default order</div>
-									</Button>
-								</div>
+								{#if hasDefaultOrder}
+									<div class="flex justify-center">
+										<Button
+											variant="transparent"
+											size="sm"
+											ariaLabel="Use default order"
+											onclick={async () => {
+												const def = await defaultStore.getDefault();
+												if (!def) {
+													notifications.info('No saved default order');
+													return;
+												}
+												const cloned = { ...def, date: format(date, 'yyyy-MM-dd'), tempOrder: true };
+												updateOrderForKitchen(orders, cloned);
+											}}
+										>
+											<div class="text-xs text-gray-400 text-center">Use default order</div>
+										</Button>
+									</div>
+								{:else}
+									<div class="text-xs text-gray-400 text-center">
+										Save an order as default to quickly reuse it
+									</div>
+								{/if}
 							</Card>
 						{/if}
 


### PR DESCRIPTION
Summary
- Show a hint when there is no default order set.
- Avoid rendering an unnecessary button when a default order is absent.

Changes
- Adds UI hint/message to indicate no default order exists.
- Removes or conditionally hides the button that would be redundant without a default order.